### PR TITLE
将PWM.duty替换成了PWM.duty_u16

### DIFF
--- a/driver/st7735_buf.py
+++ b/driver/st7735_buf.py
@@ -144,7 +144,7 @@ class ST7735(framebuf.FrameBuffer):
             self.cs = Pin(cs, Pin.OUT, Pin.PULL_DOWN)
         if bl is not None:
             self.bl = PWM(Pin(bl, Pin.OUT))
-            self.bl.duty(1023)
+            self.bl.duty_u16(1023)
         else:
             self.bl = None
         self._rotate = rotate

--- a/driver/st7735_spi.py
+++ b/driver/st7735_spi.py
@@ -142,7 +142,7 @@ class ST7735:
             self.cs = Pin(cs, Pin.OUT, Pin.PULL_DOWN)
         if bl is not None:
             self.bl = PWM(Pin(bl, Pin.OUT))
-            self.bl.duty(1023)
+            self.bl.duty_u16(1023)
         else:
             self.bl = None
         self._rotate = rotate

--- a/driver/st7789_buf.py
+++ b/driver/st7789_buf.py
@@ -179,7 +179,7 @@ class ST7789(framebuf.FrameBuffer):
             self.cs = Pin(cs, Pin.OUT, Pin.PULL_DOWN)
         if bl is not None:
             self.bl = PWM(Pin(bl, Pin.OUT))
-            self.bl.duty(1023)
+            self.bl.duty_u16(1023)
         else:
             self.bl = None
         self._rotate = rotate

--- a/driver/st7789_spi.py
+++ b/driver/st7789_spi.py
@@ -177,7 +177,7 @@ class ST7789:
             self.cs = Pin(cs, Pin.OUT, Pin.PULL_DOWN)
         if bl is not None:
             self.bl = PWM(Pin(bl, Pin.OUT))
-            self.bl.duty(1023)
+            self.bl.duty_u16(1023)
         else:
             self.bl = None
         self._rotate = rotate


### PR DESCRIPTION
我在使用树莓派pico驱动st7735时，报错

> AttributeError: type object 'PWM' has no attribute 'duty'

经检查，应将PWM.duty替换为PWM.duty_u16，经过修改后测试可以正常使用
因此，我将ST7735与ST7789中出现的几处PWM.duty替换为了PWM.duty_u16